### PR TITLE
Add ZLE handler support

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -291,6 +291,7 @@ async_stop_worker() {
 		for k v in ${(@kv)ASYNC_PTYS}; do
 			if [[ $v == $worker ]]; then
 				zle -F $k
+				unset "ASYNC_PTYS[$k]"
 			fi
 		done
 		async_unregister_callback $worker

--- a/async.zsh
+++ b/async.zsh
@@ -166,6 +166,7 @@ async_process_results() {
 
 # Watch worker for output
 _async_zle_watcher() {
+	setopt localoptions noshwordsplit
 	typeset -gA ASYNC_PTYS ASYNC_CALLBACKS
 	local worker=$ASYNC_PTYS[$1]
 	local callback=$ASYNC_CALLBACKS[$worker]

--- a/async.zsh
+++ b/async.zsh
@@ -330,12 +330,12 @@ async_init() {
 
 	# Check if zsh/zpty returns a file descriptor or not, shell must also be interactive
 	ASYNC_USE_ZLE_HANDLER=0
-	typeset -h REPLY
-	zpty _async_test cat
-	if (( REPLY )) && [[ -o interactive ]]; then
-		ASYNC_USE_ZLE_HANDLER=1
-	fi
-	zpty -d _async_test
+	[[ -o interactive ]] && {
+		typeset -h REPLY
+		zpty _async_test cat
+		(( REPLY )) && ASYNC_USE_ZLE_HANDLER=1
+		zpty -d _async_test
+	}
 }
 
 async() {

--- a/async.zsh
+++ b/async.zsh
@@ -331,7 +331,7 @@ async_init() {
 	ASYNC_USE_ZLE_HANDLER=0
 	typeset -h REPLY
 	zpty _async_test cat
-	if (( REPLY )) && [[ $- == *i* ]]; then
+	if (( REPLY )) && [[ -o interactive ]]; then
 		ASYNC_USE_ZLE_HANDLER=1
 	fi
 	zpty -d _async_test

--- a/async.zsh
+++ b/async.zsh
@@ -212,7 +212,7 @@ async_register_callback() {
 
 	ASYNC_CALLBACKS[$worker]="$*"
 
-	if (( ! ASYNC_DISABLE_KILL )); then
+	if (( ! ASYNC_USE_ZLE_HANDLER )); then
 		trap '_async_notify_trap' WINCH
 	fi
 }
@@ -280,7 +280,7 @@ async_start_worker() {
 		return 1
 	}
 
-	if (( REPLY )); then
+	if (( ASYNC_USE_ZLE_HANDLER )); then
 		ASYNC_PTYS[$REPLY]=$worker
 		zle -F $REPLY _async_zle_watcher
 
@@ -327,12 +327,12 @@ async_init() {
 	zmodload zsh/zpty
 	zmodload zsh/datetime
 
-	# Check if zsh/zpty returns a fd or not
-	ASYNC_DISABLE_KILL=0
+	# Check if zsh/zpty returns a file descriptor or not, shell must also be interactive
+	ASYNC_USE_ZLE_HANDLER=0
 	typeset -h REPLY
 	zpty _async_test cat
-	if (( REPLY )); then
-		ASYNC_DISABLE_KILL=1
+	if (( REPLY )) && [[ $- == *i* ]]; then
+		ASYNC_USE_ZLE_HANDLER=1
 	fi
 	zpty -d _async_test
 }


### PR DESCRIPTION
Since `zsh 5.1` zpty returns an fd and ZLE can be used to listen to that fd for output, this way we do not need to use kill-signals to notify that a job is done.