### PR TITLE
Added link to function definition.

### DIFF
--- a/async
+++ b/async
@@ -1,0 +1,1 @@
+async.zsh


### PR DESCRIPTION
This quick change adds a symbolic link to async.zsh so this repo can be included in the zsh functions/modules definitions. I use [Sorin Ionescu's Prezto](https://github.com/sorin-ionescu/prezto) to manage my zsh configuration, so the symlink was necessary to add this to the local module tree.