### PR TITLE
Add support for ZLE watcher on legacy zsh (pre-5.2)

### DIFF
--- a/async_test.zsh
+++ b/async_test.zsh
@@ -461,10 +461,6 @@ zpty_deinit() {
 }
 
 test_zle_watcher() {
-	if [[ $ZSH_VERSION < 5.2 ]]; then
-		t_skip "zpty does not return a file descriptor on zsh <5.2"
-	fi
-
 	zpty_init '
 		emulate -R zsh
 		setopt zle


### PR DESCRIPTION
By deducing the file descriptor that zpty will use we no longer need to rely on kill signals on older versions of zsh.

This has worked so far in my testing, but I have not confirmed that this logic works 100% with how zsh decides what file descriptor to use.