### PR TITLE
Avoid side-effects from RC_EXPAND_PARAM in async_job

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -279,8 +279,6 @@ _async_zle_watcher() {
 # 	async_job <worker_name> <my_function> [<function_params>]
 #
 async_job() {
-	# Reset all options to defaults inside async job.
-	emulate -R zsh
 	setopt localoptions noshwordsplit
 
 	local worker=$1; shift
@@ -291,7 +289,8 @@ async_job() {
 		cmd=(${(q)cmd})  # Quote special characters in multi argument commands.
 	fi
 
-	zpty -w $worker $cmd$'\0'
+	# Quote the cmd in case RC_EXPAND_PARAM is set.
+	zpty -w $worker "$cmd"$'\0'
 }
 
 # This function traps notification signals and calls all registered callbacks

--- a/async.zsh
+++ b/async.zsh
@@ -279,6 +279,8 @@ _async_zle_watcher() {
 # 	async_job <worker_name> <my_function> [<function_params>]
 #
 async_job() {
+	# Reset all options to defaults inside async job.
+	emulate -R zsh
 	setopt localoptions noshwordsplit
 
 	local worker=$1; shift

--- a/async_test.zsh
+++ b/async_test.zsh
@@ -431,6 +431,26 @@ test_async_worker_survives_termination_of_other_worker() {
 	(( $#result == 5 )) || t_error "wanted a result, got (${(@Vq)result})"
 }
 
+test_async_job_with_rc_expand_param() {
+	setopt localoptions rcexpandparam 
+
+	# Make sure to test with multiple options
+	local -a result
+	cb() { result=("$@") }
+
+	async_start_worker test
+	async_job test print "hello world"
+	while ! async_process_results test cb; do :; done
+	async_stop_worker test
+
+	[[ $result[1] = print ]] || t_error "want command name: print, got" $result[1]
+	[[ $result[2] = 0 ]] || t_error "want exit code: 0, got" $result[2]
+
+	[[ $result[3] = "hello world" ]] || {
+		t_error "want output: \"hello world\", got" ${(Vq-)result[3]}
+	}
+}
+
 zpty_init() {
 	zmodload zsh/zpty
 


### PR DESCRIPTION
It's currently causing issues with RC_EXPAND_PARAM set - essentially breaking the jobs when there are multiple arguments.

Looks like it started here: https://github.com/mafredri/zsh-async/commit/34d6f7198c4d3fe0a6c3c553764886510ffe3332