### PR TITLE
Test for all zsh options and handle edge cases

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -204,7 +204,7 @@ _async_worker() {
 # 	$5 = resulting stderr from execution
 #
 async_process_results() {
-	setopt localoptions noshwordsplit
+	setopt localoptions unset noshwordsplit noksharrays noposixidentifiers noposixstrings
 
 	local worker=$1
 	local callback=$2
@@ -279,7 +279,7 @@ _async_zle_watcher() {
 # 	async_job <worker_name> <my_function> [<function_params>]
 #
 async_job() {
-	setopt localoptions noshwordsplit
+	setopt localoptions noshwordsplit noksharrays noposixidentifiers noposixstrings
 
 	local worker=$1; shift
 

--- a/async.zsh
+++ b/async.zsh
@@ -297,6 +297,7 @@ async_job() {
 _async_notify_trap() {
 	setopt localoptions noshwordsplit
 
+	local k
 	for k in ${(k)ASYNC_CALLBACKS}; do
 		async_process_results $k ${ASYNC_CALLBACKS[$k]} trap
 	done
@@ -443,7 +444,7 @@ async_start_worker() {
 async_stop_worker() {
 	setopt localoptions noshwordsplit
 
-	local ret=0
+	local ret=0 worker k v
 	for worker in $@; do
 		# Find and unregister the zle handler for the worker
 		for k v in ${(@kv)ASYNC_PTYS}; do

--- a/async_test.zsh
+++ b/async_test.zsh
@@ -430,8 +430,56 @@ test_async_worker_survives_termination_of_other_worker() {
 	(( $#result == 5 )) || t_error "wanted a result, got (${(@Vq)result})"
 }
 
+setopt_helper() {
+	setopt localoptions $1
+
+	# Make sure to test with multiple options
+	local -a result
+	cb() { result=("$@") }
+
+	async_start_worker test
+	async_job test print "hello world"
+	while ! async_process_results test cb; do :; done
+	async_stop_worker test
+
+	# At this point, ksh arrays will only mess with the test.
+	setopt noksharrays
+
+	[[ $result[1] = print ]] || t_fatal "$1 want command name: print, got" $result[1]
+	[[ $result[2] = 0 ]] || t_fatal "$1 want exit code: 0, got" $result[2]
+
+	[[ $result[3] = "hello world" ]] || {
+		t_fatal "$1 want output: \"hello world\", got" ${(Vq-)result[3]}
+	}
+}
+
+test_all_options() {
+	local -a opts exclude
+
+	# Make sure worker is stopped, even if tests fail.
+	t_defer async_stop_worker test
+
+	{ sleep 5 && t_fatal "timed out" } &
+	local tpid=$!
+
+	opts=(${(k)options})
+
+	# These options can't be tested.
+	exclude=(zle interactive restricted shinstdin stdin onecmd singlecommand)
+
+	for opt in ${opts:|exclude}; do
+		if [[ $options[$opt] = on ]]; then
+			setopt_helper no$opt
+		else
+			setopt_helper $opt
+		fi
+	done 2>/dev/null  # Remove redirect to see output.
+
+	kill $tpid  # Stop timeout.
+}
+
 test_async_job_with_rc_expand_param() {
-	setopt localoptions rcexpandparam 
+	setopt localoptions rcexpandparam
 
 	# Make sure to test with multiple options
 	local -a result

--- a/async_test.zsh
+++ b/async_test.zsh
@@ -456,6 +456,10 @@ setopt_helper() {
 test_all_options() {
 	local -a opts exclude
 
+	if [[ $ZSH_VERSION == 5.0.2 ]]; then
+		t_skip "Test is not reliable on zsh 5.0.2"
+	fi
+
 	# Make sure worker is stopped, even if tests fail.
 	t_defer async_stop_worker test
 

--- a/async_test.zsh
+++ b/async_test.zsh
@@ -459,13 +459,16 @@ test_all_options() {
 	# Make sure worker is stopped, even if tests fail.
 	t_defer async_stop_worker test
 
-	{ sleep 5 && t_fatal "timed out" } &
+	{ sleep 10 && t_fatal "timed out" } &
 	local tpid=$!
 
 	opts=(${(k)options})
 
 	# These options can't be tested.
-	exclude=(zle interactive restricted shinstdin stdin onecmd singlecommand)
+	exclude=(
+		zle interactive restricted shinstdin stdin onecmd singlecommand
+		warnnestedvar
+	)
 
 	for opt in ${opts:|exclude}; do
 		if [[ $options[$opt] = on ]]; then


### PR DESCRIPTION
Enabling / disabling all zsh options caught some edge cases that weren't handled. I don't know if anyone actually uses `posixidentifiers`, `posixstrings` or even disables `unset`, but they break `async_process_results` / `async_job` so might as well enforce them.