### PR TITLE
Prefix async job output to prevent external corruption

### DIFF
--- a/async_test.zsh
+++ b/async_test.zsh
@@ -7,8 +7,8 @@ test__async_job_print_hi() {
 	local line
 	local -a out
 	line=$(_async_job print hi)
-	# Remove trailing null, parse, unquote and interpret as array.
-	line=$line[1,$#line-1]
+	# Remove leading/trailing null, parse, unquote and interpret as array.
+	line=$line[2,$#line-1]
 	out=("${(@Q)${(z)line}}")
 
 	coproc exit
@@ -396,8 +396,10 @@ test_async_flush_jobs() {
 	# TODO: Confirm that they no longer exist in the process tree.
 	local output
 	output="${(Q)$(ASYNC_DEBUG=1 async_flush_jobs test)}"
-	[[ $output = *'print_four 0 4'* ]] || {
-		t_error "want discarded output 'print_four 0 4' when ASYNC_DEBUG=1, got ${(Vq-)output}"
+	# NOTE(mafredri): First 'p' in print_four is lost when null-prefixing
+	# _async_job output.
+	[[ $output = *'rint_four 0 4'* ]] || {
+		t_error "want discarded output 'rint_four 0 4' when ASYNC_DEBUG=1, got ${(Vq-)output}"
 	}
 
 	# Check that the killed job did not produce output.


### PR DESCRIPTION
If an external process interferes with the async worker (e.g. writes its
pty), the output can become corrupt. To minimize this occurance we now
prefix all job output with the NULL character, instead of just separate
on NULLs (suffix).