### PR TITLE
prevent infinite loop in case of broken zpty file descriptor

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -306,6 +306,22 @@ _async_zle_watcher() {
 	local worker=$ASYNC_PTYS[$1]
 	local callback=$ASYNC_CALLBACKS[$worker]
 
+	if [[ -n $2 ]]; then
+		# from man zshzle(1):
+		# `hup' for a disconnect, `nval' for a closed or otherwise
+		# invalid descriptor, or `err' for any other condition.
+		# Systems that support only the `select' system call always use
+		# `err'.
+
+		# this has the side effect to unregister the broken file descriptor
+		async_stop_worker $worker
+
+		if [[ -n $callback ]]; then
+			$callback '[async]' 2 "" 0 "$worker:zle -F $1 returned error $2" 0
+		fi
+		return
+	fi;
+
 	if [[ -n $callback ]]; then
 		async_process_results $worker $callback watcher
 	fi


### PR DESCRIPTION
In some cases, the fd created by zpty can become corrupted: if the other
end was disconnected, if the fd was closed and so on.
If we ignore this condition, then we enter a infinite loop. This eats 100% of a cpu and is very annoying.

Instead, when the fd becomes invalid, this commit unregisters the corresponding
worker and notifies the callback.
The error code was chosen to be "[async]" because the readme mentions this is how some existing errors are already notified to callbacks.

I have discovered this problem as part of the pure prompt. This happens randomly about once a week. I have been using this fork for some time, now, and the problem has disappeared.

The tests still pass.