### PR TITLE
Improved error state handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   matrix:
     # Use _ZSH_VERSION since if ZSH_VERSION is present, travis cacher thinks it
     # is running in zsh and tries to use zsh specific functions.
+    - _ZSH_VERSION=5.8
+    - _ZSH_VERSION=5.7.1
+    - _ZSH_VERSION=5.7
     - _ZSH_VERSION=5.6.2
     - _ZSH_VERSION=5.5.1
     - _ZSH_VERSION=5.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ env:
     - _ZSH_VERSION=5.2
     - _ZSH_VERSION=5.1.1
     - _ZSH_VERSION=5.0.8
-    - _ZSH_VERSION=5.0.2
+    # Zsh 5.0.2 has issues on Travis, missing signals.
+    # - _ZSH_VERSION=5.0.2
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `callback_function` is called with the following parameters:
 
 Possible error return codes for the job name `[async]`:
 
-* `1` Corrupted worker output.
+* `1` Corrupt worker output.
 * `2` ZLE watcher detected an error on the worker fd.
 * `3` Response from async_job when worker is missing.
 * `130` Async worker crashed, this should not happen but it can mean the file descriptor has become corrupt. This must be followed by a `async_stop_worker [name]` and then the worker and tasks should be restarted. It is unknown why this happens.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ The `callback_function` is called with the following parameters:
 * `$6` has next result in buffer (0 = buffer empty, 1 = yes)
   * This means another async job has completed and is pending in the buffer, it's very likely that your callback function will be called a second time (or more) in this execution. It's generally a good idea to e.g. delay prompt updates (`zle reset-prompt`) until the buffer is empty to prevent strange states in ZLE.
 
+Possible error return codes for the job name `[async]`:
+
+* `1` Corrupted worker output.
+* `2` ZLE watcher detected an error on the worker fd.
+* `3` Response from async_job when worker is missing.
+* `130` Async worker crashed, this should not happen but it can mean the file descriptor has become corrupt. This must be followed by a `async_stop_worker [name]` and then the worker and tasks should be restarted. It is unknown why this happens.
+
 #### `async_register_callback <worker_name> <callback_function>`
 
 Register a callback for completed jobs. As soon as a job is finished, `async_process_results` will be called with the specified callback function. This requires that a worker is initialized with the -n (notify) option.

--- a/async.zsh
+++ b/async.zsh
@@ -404,6 +404,7 @@ async_worker_eval() {
 		cmd=(${(q)cmd})  # Quote special characters in multi argument commands.
 	fi
 
+	# Quote the cmd in case RC_EXPAND_PARAM is set.
 	_async_send_job $0 $worker "_async_eval $cmd"
 }
 

--- a/async.zsh
+++ b/async.zsh
@@ -83,7 +83,7 @@ _async_worker() {
 	# worker would simply exit (stop working) even though visible in the list
 	# of zpty's (zpty -L). This has been fixed around the time of Zsh 5.4
 	# (not released).
-	if is-at-least 5.4.1; then
+	if ! is-at-least 5.4.1; then
 		TRAPHUP() {
 			return 0  # Return 0, indicating signal was handled.
 		}

--- a/async.zsh
+++ b/async.zsh
@@ -3,12 +3,12 @@
 #
 # zsh-async
 #
-# version: 1.8.0-dev1
+# version: 1.8.0-dev2
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
 
-typeset -g ASYNC_VERSION=1.8.0-dev1
+typeset -g ASYNC_VERSION=1.8.0-dev2
 # Produce debug output from zsh-async when set to 1.
 typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
 

--- a/async.zsh
+++ b/async.zsh
@@ -81,10 +81,13 @@ _async_worker() {
 	# When a zpty is deleted (using -d) all the zpty instances created before
 	# the one being deleted receive a SIGHUP, unless we catch it, the async
 	# worker would simply exit (stop working) even though visible in the list
-	# of zpty's (zpty -L).
-	TRAPHUP() {
-		return 0  # Return 0, indicating signal was handled.
-	}
+	# of zpty's (zpty -L). This has been fixed around the time of Zsh 5.4
+	# (not released).
+	if is-at-least 5.4.1; then
+		TRAPHUP() {
+			return 0  # Return 0, indicating signal was handled.
+		}
+	fi
 
 	local -A storage
 	local unique=0
@@ -530,7 +533,7 @@ async_start_worker() {
 	# Re-enable it if it was enabled, for debugging.
 	(( has_xtrace )) && setopt xtrace
 
-	if [[ $ZSH_VERSION < 5.0.8 ]]; then
+	if ! is-at-least 5.0.8; then
 		# For ZSH versions older than 5.0.8 we delay a bit to give
 		# time for the worker to start before issuing commands,
 		# otherwise it will not be ready to receive them.
@@ -591,6 +594,9 @@ async_init() {
 
 	zmodload zsh/zpty
 	zmodload zsh/datetime
+
+	# Load is-at-least for reliable version check.
+	autoload -Uz is-at-least
 
 	# Check if zsh/zpty returns a file descriptor or not,
 	# shell must also be interactive with zle enabled.

--- a/async.zsh
+++ b/async.zsh
@@ -194,6 +194,11 @@ _async_worker() {
 			return $(( 127 + 1 ))
 		}
 
+		# We need to clean the input here because sometimes when a zpty
+		# has died and been respawned, messages will be prefixed with a
+		# carraige return (\r, or \C-M).
+		request=${request#$'\C-M'}
+
 		# Check for non-job commands sent to worker
 		case $request in
 			_unset_trap)  notify_parent=0; continue;;

--- a/async.zsh
+++ b/async.zsh
@@ -374,14 +374,14 @@ _async_send_job() {
 	local worker=$2
 	shift 2
 
-	zpty -t $worker || {
+	zpty -t $worker &>/dev/null || {
 		typeset -gA ASYNC_PTYS ASYNC_CALLBACKS
 		local callback=$ASYNC_CALLBACKS[$worker]
 
 		if [[ -n $callback ]]; then
 			$callback '[async]' 3 "" 0 "$0:$LINENO: error: no such worker: $worker" 0
 		else
-			print -u2 "$caller: no sych async worker: $worker"
+			print -u2 "$caller: no such async worker: $worker"
 		fi
 		return 1
 	}

--- a/async.zsh
+++ b/async.zsh
@@ -49,7 +49,7 @@ _async_job() {
 		} 2> >(stderr=$(cat) && print -r -n - " "${(q)stderr}$'\0')
 	)"
 	if [[ $out != $'\0'*$'\0' ]]; then
-		# Corrupted output (probably a aborted job?), skipping.
+		# Corrupted output (aborted job?), skipping.
 		return
 	fi
 

--- a/async.zsh
+++ b/async.zsh
@@ -175,9 +175,11 @@ _async_worker() {
 		# Name of the job (first argument).
 		local job=$cmd[1]
 
-		# If worker should perform unique jobs
-		if (( unique )); then
-			# Check if a previous job is still running, if yes, let it finnish
+		# Check if a worker should perform unique jobs, unless
+		# this is an eval since they run synchronously.
+		if (( !do_eval )) && (( unique )); then
+			# Check if a previous job is still running, if yes,
+			# skip this job and let the previous one finish.
 			for pid in ${${(v)jobstates##*:*:}%\=*}; do
 				if [[ ${storage[$job]} == $pid ]]; then
 					continue 2

--- a/async.zsh
+++ b/async.zsh
@@ -3,12 +3,12 @@
 #
 # zsh-async
 #
-# version: 1.8.0-dev
+# version: 1.8.0-dev1
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
 
-typeset -g ASYNC_VERSION=1.8.0-dev
+typeset -g ASYNC_VERSION=1.8.0-dev1
 # Produce debug output from zsh-async when set to 1.
 typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
 

--- a/async.zsh
+++ b/async.zsh
@@ -3,12 +3,12 @@
 #
 # zsh-async
 #
-# version: 1.7.2
+# version: 1.8.0-dev
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
 
-typeset -g ASYNC_VERSION=1.7.2
+typeset -g ASYNC_VERSION=1.8.0-dev
 # Produce debug output from zsh-async when set to 1.
 typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
 

--- a/async_test.zsh
+++ b/async_test.zsh
@@ -139,20 +139,6 @@ test_async_process_results_stress() {
 	integer iter=40 timeout=5
 	for i in {1..$iter}; do
 		async_job test "print -n $i"
-
-		# TODO: Figure out how we can remove sleep & process here.
-
-		# If we do not sleep here, we end up losing some of the commands sent to
-		# async_job (~90 get sent). This could possibly be due to the zpty
-		# buffer being full (see below).
-		sleep 0.00001
-		# Without processing resuls we occasionally run into 'print -n 39'
-		# failing due to the command name and exit status missing. Sample output
-		# from processing for 39 (stdout, time, stderr):
-		#   $'39 0.0056798458 '
-		# This is again, probably due to the zpty buffer being full, we only
-		# need to ensure that not too many commands are run before we process.
-		(( iter % 6 == 0 )) && async_process_results test cb
 	done
 
 	float start=$EPOCHSECONDS

--- a/test.zsh
+++ b/test.zsh
@@ -240,9 +240,10 @@ run_test_module() {
 }
 
 cleanup() {
+	trap '' HUP
+	kill -HUP -$$ 2>/dev/null
 	trap - HUP
 	kill -HUP $$ 2>/dev/null
-	kill -HUP -$$ 2>/dev/null
 }
 
 trap cleanup EXIT INT HUP QUIT TERM USR1
@@ -260,4 +261,7 @@ for tf in ${~TEST_GLOB}/*_test.(zsh|sh); do
 	(( $? )) && failed=1
 done
 
+trap - EXIT
+trap '' HUP
+kill -HUP -$$ 2>/dev/null
 exit $failed


### PR DESCRIPTION
This PR improves the reliability of async workers and introduces a way to detect worker crashes. In the event that a worker crashes, `zsh-async` will inform of this via the callback and it is up to the user to restart the worker and all tasks that failed as a result.