### PR TITLE
Improve worker startup procedure in async_start_worker

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -526,7 +526,8 @@ async_start_worker() {
 	setopt localoptions noshwordsplit
 
 	local worker=$1; shift
-	local args=($@)
+	local -a args
+	args=("$@")
 	zpty -t $worker &>/dev/null && return
 
 	typeset -gA ASYNC_PTYS

--- a/async.zsh
+++ b/async.zsh
@@ -3,12 +3,12 @@
 #
 # zsh-async
 #
-# version: 1.8.0-dev2
+# version: 1.8.0-dev3
 # author: Mathias Fredriksson
 # url: https://github.com/mafredri/zsh-async
 #
 
-typeset -g ASYNC_VERSION=1.8.0-dev2
+typeset -g ASYNC_VERSION=1.8.0-dev3
 # Produce debug output from zsh-async when set to 1.
 typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
 


### PR DESCRIPTION
This PR improves the startup procedure in `async_start_worker` and starts with ZLE watcher from the get-go, when available.