### PR TITLE
Use a regular space

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -325,7 +325,7 @@ async_process_results() {
 			else
 				# In case of corrupt data, invoke callback with *async* as job
 				# name, non-zero exit status and an error message on stderr.
-				$callback "[async]" 1 "" 0 "$0:$LINENO: error: bad format, got ${#items} items (${(q)items})" $has_next
+				$callback "[async]" 1 "" 0 "$0:$LINENO: error: bad format, got ${#items} items (${(q)items})" $has_next
 			fi
 		done
 	done


### PR DESCRIPTION
Sublime Text 4 showed the space as `<0ax0>`

    irb(main):016:0> " ".bytes
    => [194, 160]
    irb(main):017:0> " ".bytes
    => [32]

That's a "NO-BREAK SPACE" in UTF-8: https://en.wikipedia.org/wiki/Non-breaking_space#Encodings

It is easy to accidentally type the no-break space in macOS (Option+Space)