### PR TITLE
Create .gitignore for *.zwc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# zsh word code files
+*.zwc


### PR DESCRIPTION
Created a .gitignore file that ignores the zsh word code (*.zwc) compiled with the zcompile command for zsh scripts.